### PR TITLE
Fix header links with relative_url filter

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <!-- _includes/header.html  (no changes to your markup) -->
 <header class="flex items-center justify-between px-4 py-6 sm:px-8">
   <!-- Left: Logo -->
-  <a href="index.html">
+  <a href="{{ '/' | relative_url }}">
     <img src="{{ '/images/logo.png' | relative_url }}" alt="Sympnoia Logo" class="h-24 w-auto">
   </a>
 
@@ -25,13 +25,13 @@
 <div id="navModal" class="fixed top-20 right-4 sm:right-8 md:right-10 z-50 hidden w-24">
   <div class="bg-[#1e1e1e]/90 rounded-xl shadow-lg p-6 w-64">
     <ul class="space-y-3">
-      <li><a href="index.html"        class="menu-entry">Home</a></li>
-      <li><a href="writings.html"     class="menu-entry">Writings</a></li>
-      <li><a href="philosophy.html"   class="menu-entry">↳ Philosophy</a></li>
-      <li><a href="prose.html"        class="menu-entry">↳ Prose</a></li>
-      <li><a href="blog.html"         class="menu-entry">Blog</a></li>
-      <li><a href="gallery.html"      class="menu-entry">Gallery</a></li>
-      <li><a href="glossary.html"     class="menu-entry">Glossary</a></li>
+      <li><a href="{{ '/' | relative_url }}"        class="menu-entry">Home</a></li>
+      <li><a href="{{ '/writings.html'   | relative_url }}" class="menu-entry">Writings</a></li>
+      <li><a href="{{ '/philosophy.html' | relative_url }}" class="menu-entry">↳ Philosophy</a></li>
+      <li><a href="{{ '/prose.html'      | relative_url }}" class="menu-entry">↳ Prose</a></li>
+      <li><a href="{{ '/blog.html'       | relative_url }}" class="menu-entry">Blog</a></li>
+      <li><a href="{{ '/gallery.html'    | relative_url }}" class="menu-entry">Gallery</a></li>
+      <li><a href="{{ '/glossary.html'   | relative_url }}" class="menu-entry">Glossary</a></li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- ensure navigation links use Jekyll's `relative_url`

## Testing
- `jekyll --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684049432048832bbdb4a99d2c4fcb51