### PR TITLE
Add font and size options to reader mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Website for Sympnoia: A shared ethical and philosophical journey.
 
 Add new papers to the `_philosophy` directory. Each file only needs standard front matter with `layout: philosophy` followed by your markdown content. The philosophy layout automatically provides the styled container and options button, so do not include your own `<style>` or `<main>` wrappers.
 
-Within the reader you can adjust the color scheme and width using the options
-button in the top-right corner. Five accessible color presets and three width
-choices are provided. Defaults are applied so pages render correctly even when
+Within the reader you can adjust the color scheme, font style, font size and width using the options
+button in the top-right corner. Five accessible color presets (Olive is the default) and three width
+choices are provided. Four font pairings and four font sizes are available. Defaults are applied so pages render correctly even when
 JavaScript is disabled.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,6 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{{ page.title | default: "Sympnoia" }}</title>
 
+  <!-- Reading fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=EB+Garamond&family=Fira+Sans+Condensed&family=IBM+Plex+Mono&family=Lora&family=Playfair+Display&family=Source+Sans+Pro&family=Libre+Franklin&display=swap" rel="stylesheet">
+
   <!-- Tailwind (same CDN link you used) -->
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
 

--- a/_layouts/philosophy.html
+++ b/_layouts/philosophy.html
@@ -7,12 +7,17 @@ layout: default
     --reader-bg:   #1e2a1e; /* deep olive */
     --reader-text: #f1e9d2; /* warm ivory text */
     --reader-max-w: 56rem;
+    --reader-font-body: Georgia, serif;
+    --reader-font-title: "EB Garamond", serif;
+    --reader-font-size: 1rem;
   }
 
   .content-box {
     background-color: var(--reader-bg);
     color: var(--reader-text);
     max-width: var(--reader-max-w);
+    font-family: var(--reader-font-body);
+    font-size: var(--reader-font-size);
     border-radius: 1rem;
     padding: 2rem;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
@@ -22,10 +27,15 @@ layout: default
     line-height: 1.7;
   }
 
+  .content-box h1,
   .content-box h2,
-  .content-box h3 {
+  .content-box h3,
+  .content-box h4,
+  .content-box h5,
+  .content-box h6 {
     margin-top: 1.5rem;
     font-weight: bold;
+    font-family: var(--reader-font-title);
   }
 </style>
 
@@ -36,15 +46,26 @@ layout: default
   {{ content }}
   <div id="optionsMenu" class="hidden absolute top-10 right-2 rounded-lg shadow-lg p-4 space-y-2" style="background:var(--reader-bg);color:var(--reader-text)">
     <div class="font-bold">Color Scheme</div>
-    <button data-scheme="default" class="block w-full text-left">Default</button>
+    <button data-scheme="olive" class="block w-full text-left">Olive</button>
     <button data-scheme="duskrose" class="block w-full text-left">Duskrose</button>
     <button data-scheme="dark" class="block w-full text-left">Dark</button>
     <button data-scheme="blue" class="block w-full text-left">Blue</button>
     <button data-scheme="sepia" class="block w-full text-left">Sepia</button>
+    <div class="font-bold mt-3">Font Style</div>
+    <button data-font="classic" class="block w-full text-left">Classic Serif</button>
+    <button data-font="modern" class="block w-full text-left">Modern Serif</button>
+    <button data-font="humanist" class="block w-full text-left">Humanist Sans</button>
+    <button data-font="mono" class="block w-full text-left">Literary Monospace</button>
+    <div class="font-bold mt-3">Font Size</div>
+    <button data-fsize="small"   class="block w-full text-left">Small</button>
+    <button data-fsize="default" class="block w-full text-left">Default</button>
+    <button data-fsize="large"   class="block w-full text-left">Large</button>
+    <button data-fsize="huge"    class="block w-full text-left">Huge</button>
     <div class="font-bold mt-3">Reader Size</div>
     <button data-size="narrow" class="block w-full text-left">Narrow</button>
     <button data-size="medium" class="block w-full text-left">Medium</button>
     <button data-size="wide" class="block w-full text-left">Wide</button>
+    <button id="resetOptions" class="block w-full text-left mt-2">Reset</button>
   </div>
 </main>
 
@@ -56,7 +77,7 @@ layout: default
   }
 
   const schemes = {
-  default: { bg: '#192519', text: '#f1e9d2' },         // sdark olive green
+  olive: { bg: '#192519', text: '#f1e9d2' },         // dark olive green
   duskrose: { bg: '#4a263a', text: '#fbecea' },           // deep muted rose/brown-purple
   dark: { bg: '#000000', text: '#ffffff' },             // black and white
   blue: { bg: '#001f2b', text: '#fdf6e3' },             // deep solarized blue
@@ -69,6 +90,52 @@ layout: default
     medium: '56rem',
     wide:   '72rem'
   };
+
+  const fonts = {
+    classic:  { body: 'Georgia, serif',                      title: '"EB Garamond", serif' },
+    modern:   { body: '\'Lora\', serif',                     title: '\'Playfair Display\', serif' },
+    humanist: { body: '\'Source Sans Pro\', sans-serif',     title: '\'Libre Franklin\', sans-serif' },
+    mono:     { body: '\'IBM Plex Mono\', monospace',        title: '\'Fira Sans Condensed\', sans-serif' }
+  };
+
+  const sizes = {
+    small:   '0.875rem',
+    default: '1rem',
+    large:   '1.125rem',
+    huge:    '1.25rem'
+  };
+
+  function storageSet(key, val) {
+    try {
+      localStorage.setItem(key, val);
+    } catch(e) {
+      document.cookie = `${key}=${val};path=/`;
+    }
+  }
+
+  function storageGet(key) {
+    try {
+      return localStorage.getItem(key);
+    } catch(e) {
+      const m = document.cookie.match(new RegExp('(^|;)\\s*'+key+'=([^;]+)'));
+      return m ? m[2] : null;
+    }
+  }
+
+  function applyFontStyle(name) {
+    const f = fonts[name];
+    if (!f) return;
+    document.documentElement.style.setProperty('--reader-font-body', f.body);
+    document.documentElement.style.setProperty('--reader-font-title', f.title);
+    storageSet('readerFontStyle', name);
+  }
+
+  function applyFontSize(name) {
+    const s = sizes[name];
+    if (!s) return;
+    document.documentElement.style.setProperty('--reader-font-size', s);
+    storageSet('readerFontSize', name);
+  }
 
   document.querySelectorAll('[data-scheme]').forEach(btn => {
     btn.addEventListener('click', () => {
@@ -90,4 +157,40 @@ layout: default
       }
     });
   });
+
+  document.querySelectorAll('[data-font]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      applyFontStyle(btn.dataset.font);
+      optsMenu.classList.add('hidden');
+    });
+  });
+
+  document.querySelectorAll('[data-fsize]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      applyFontSize(btn.dataset.fsize);
+      optsMenu.classList.add('hidden');
+    });
+  });
+
+  const resetBtn = document.getElementById('resetOptions');
+  if (resetBtn) {
+    resetBtn.addEventListener('click', () => {
+      document.documentElement.style.setProperty('--reader-bg', schemes.olive.bg);
+      document.documentElement.style.setProperty('--reader-text', schemes.olive.text);
+      document.documentElement.style.setProperty('--reader-max-w', widths.medium);
+      applyFontStyle('classic');
+      applyFontSize('default');
+      optsMenu.classList.add('hidden');
+    });
+  }
+
+  // Apply saved preferences
+  const savedFont = storageGet('readerFontStyle');
+  if (savedFont && fonts[savedFont]) {
+    applyFontStyle(savedFont);
+  }
+  const savedSize = storageGet('readerFontSize');
+  if (savedSize && sizes[savedSize]) {
+    applyFontSize(savedSize);
+  }
 </script>


### PR DESCRIPTION
## Summary
- load Google fonts required for reading mode
- extend philosophy layout to support font style & size options, persistence and reset
- rename default color scheme to "Olive" and add more menu controls
- update README with new instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68418eb671ac832bab01bc0bdab5dc62