### PR TITLE
Enhance option menu with dividers and category colors

### DIFF
--- a/_layouts/philosophy.html
+++ b/_layouts/philosophy.html
@@ -73,23 +73,26 @@ layout: default
   </div>
   <div id="optionsMenu" class="hidden absolute top-10 right-2 rounded-lg shadow-lg p-4 space-y-2" style="background:var(--reader-bg);color:var(--reader-text)">
     <button id="edgeGlowBtn" class="option-btn block w-full text-left">Edge Glow Mode <span class="indicator hidden"></span></button>
-    <div class="font-bold">Color Scheme</div>
+    <div class="font-bold text-green-300">Color Scheme</div>
     <button data-scheme="olive" class="option-btn block w-full text-left">Olive <span class="indicator hidden"></span></button>
     <button data-scheme="duskrose" class="option-btn block w-full text-left">Duskrose <span class="indicator hidden"></span></button>
     <button data-scheme="dark" class="option-btn block w-full text-left">Dark <span class="indicator hidden"></span></button>
     <button data-scheme="blue" class="option-btn block w-full text-left">Blue <span class="indicator hidden"></span></button>
     <button data-scheme="sepia" class="option-btn block w-full text-left">Sepia <span class="indicator hidden"></span></button>
-    <div class="font-bold mt-3">Font Style</div>
+    <hr class="my-2 border-gray-600" style="border-color:var(--reader-text)">
+    <div class="font-bold mt-3 text-pink-300">Font Style</div>
     <button data-font="classic" class="option-btn block w-full text-left">Classic Serif <span class="indicator hidden"></span></button>
     <button data-font="modern" class="option-btn block w-full text-left">Modern Serif <span class="indicator hidden"></span></button>
     <button data-font="humanist" class="option-btn block w-full text-left">Humanist Sans <span class="indicator hidden"></span></button>
     <button data-font="mono" class="option-btn block w-full text-left">Literary Monospace <span class="indicator hidden"></span></button>
-    <div class="font-bold mt-3">Font Size</div>
+    <hr class="my-2 border-gray-600" style="border-color:var(--reader-text)">
+    <div class="font-bold mt-3 text-yellow-300">Font Size</div>
     <button data-fsize="small"   class="option-btn block w-full text-left">Small <span class="indicator hidden"></span></button>
     <button data-fsize="default" class="option-btn block w-full text-left">Default <span class="indicator hidden"></span></button>
     <button data-fsize="large"   class="option-btn block w-full text-left">Large <span class="indicator hidden"></span></button>
     <button data-fsize="huge"    class="option-btn block w-full text-left">Huge <span class="indicator hidden"></span></button>
-    <div class="font-bold mt-3">Reader Size</div>
+    <hr class="my-2 border-gray-600" style="border-color:var(--reader-text)">
+    <div class="font-bold mt-3 text-blue-300">Reader Size</div>
     <button data-size="narrow" class="option-btn block w-full text-left">Narrow <span class="indicator hidden"></span></button>
     <button data-size="medium" class="option-btn block w-full text-left">Medium <span class="indicator hidden"></span></button>
     <button data-size="wide" class="option-btn block w-full text-left">Wide <span class="indicator hidden"></span></button>


### PR DESCRIPTION
## Summary
- visually separate each option category in the philosophy layout
- add distinct text colors for the category headers

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841a8fab28c832baf12bae09df18074