### PR TITLE
Unify reader option colours

### DIFF
--- a/_layouts/philosophy.html
+++ b/_layouts/philosophy.html
@@ -6,6 +6,7 @@ layout: default
   :root {
     --reader-bg:   #1e2a1e; /* deep olive */
     --reader-text: #f1e9d2; /* warm ivory text */
+    --category-color: #f1e9d2cc; /* slightly muted variant of text color */
     --reader-max-w: 56rem;
     --reader-font-body: Georgia, serif;
     --reader-font-title: "EB Garamond", serif;
@@ -62,6 +63,12 @@ layout: default
     border-radius: 50%;
     background-color: var(--reader-text);
   }
+
+  /* headings within the options menu and special buttons */
+  .option-category {
+    color: var(--category-color);
+    font-weight: bold;
+  }
 </style>
 
 <main class="content-box px-6 py-8 mx-auto relative">
@@ -72,32 +79,32 @@ layout: default
     {{ content }}
   </div>
   <div id="optionsMenu" class="hidden absolute top-10 right-2 rounded-lg shadow-lg p-4 space-y-2" style="background:var(--reader-bg);color:var(--reader-text)">
-    <button id="edgeGlowBtn" class="option-btn block w-full text-left">Edge Glow Mode <span class="indicator hidden"></span></button>
-    <div class="font-bold text-green-300">Color Scheme</div>
+    <button id="edgeGlowBtn" class="option-btn option-category block w-full text-left">Edge Glow Mode <span class="indicator hidden"></span></button>
+    <div class="option-category">Color Scheme</div>
     <button data-scheme="olive" class="option-btn block w-full text-left">Olive <span class="indicator hidden"></span></button>
     <button data-scheme="duskrose" class="option-btn block w-full text-left">Duskrose <span class="indicator hidden"></span></button>
     <button data-scheme="dark" class="option-btn block w-full text-left">Dark <span class="indicator hidden"></span></button>
     <button data-scheme="blue" class="option-btn block w-full text-left">Blue <span class="indicator hidden"></span></button>
     <button data-scheme="sepia" class="option-btn block w-full text-left">Sepia <span class="indicator hidden"></span></button>
     <hr class="my-2 border-gray-600" style="border-color:var(--reader-text)">
-    <div class="font-bold mt-3 text-pink-300">Font Style</div>
+    <div class="option-category mt-3">Font Style</div>
     <button data-font="classic" class="option-btn block w-full text-left">Classic Serif <span class="indicator hidden"></span></button>
     <button data-font="modern" class="option-btn block w-full text-left">Modern Serif <span class="indicator hidden"></span></button>
     <button data-font="humanist" class="option-btn block w-full text-left">Humanist Sans <span class="indicator hidden"></span></button>
     <button data-font="mono" class="option-btn block w-full text-left">Literary Monospace <span class="indicator hidden"></span></button>
     <hr class="my-2 border-gray-600" style="border-color:var(--reader-text)">
-    <div class="font-bold mt-3 text-yellow-300">Font Size</div>
+    <div class="option-category mt-3">Font Size</div>
     <button data-fsize="small"   class="option-btn block w-full text-left">Small <span class="indicator hidden"></span></button>
     <button data-fsize="default" class="option-btn block w-full text-left">Default <span class="indicator hidden"></span></button>
     <button data-fsize="large"   class="option-btn block w-full text-left">Large <span class="indicator hidden"></span></button>
     <button data-fsize="huge"    class="option-btn block w-full text-left">Huge <span class="indicator hidden"></span></button>
     <hr class="my-2 border-gray-600" style="border-color:var(--reader-text)">
-    <div class="font-bold mt-3 text-blue-300">Reader Size</div>
+    <div class="option-category mt-3">Reader Size</div>
     <button data-size="narrow" class="option-btn block w-full text-left">Narrow <span class="indicator hidden"></span></button>
     <button data-size="medium" class="option-btn block w-full text-left">Medium <span class="indicator hidden"></span></button>
     <button data-size="wide" class="option-btn block w-full text-left">Wide <span class="indicator hidden"></span></button>
     <hr class="my-2 border-gray-600" style="border-color:var(--reader-text)">
-    <button id="resetOptions" class="block w-full text-left mt-2">Reset</button>
+    <button id="resetOptions" class="option-category block w-full text-left mt-2">Reset</button>
   </div>
 </main>
 
@@ -154,6 +161,15 @@ layout: default
     }
   }
 
+  function mixColor(c1, c2, weight) {
+    const n1 = parseInt(c1.slice(1), 16);
+    const n2 = parseInt(c2.slice(1), 16);
+    const r = Math.round(((n1 >> 16) * weight) + ((n2 >> 16) * (1 - weight)));
+    const g = Math.round(((n1 >> 8 & 0xff) * weight) + ((n2 >> 8 & 0xff) * (1 - weight)));
+    const b = Math.round(((n1 & 0xff) * weight) + ((n2 & 0xff) * (1 - weight)));
+    return '#' + [r, g, b].map(x => x.toString(16).padStart(2, '0')).join('');
+  }
+
   function applyFontStyle(name) {
     const f = fonts[name];
     if (!f) return;
@@ -176,6 +192,8 @@ layout: default
     if (!s) return;
     document.documentElement.style.setProperty('--reader-bg', s.bg);
     document.documentElement.style.setProperty('--reader-text', s.text);
+    const cat = mixColor(s.text, s.bg, 0.7);
+    document.documentElement.style.setProperty('--category-color', cat);
     storageSet('readerScheme', name);
     updateIndicator('[data-scheme]', 'scheme', name);
   }


### PR DESCRIPTION
## Summary
- add `--category-color` variable for reader option headings
- style category headings, edge glow toggle, and reset with this variable
- compute colour from active scheme to keep categories distinct from entries

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6841b4512bd4832b9e8c971491246aaf