### PR TITLE
Wrap golden heights setup in IIFE

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,30 +12,35 @@
 
   <!-- Tailwind with custom golden ratio heights -->
   <script>
-    const phi = 1.61803398875;
-    const toRem = px => `${(px / 16).toFixed(6)}rem`;
-    function goldenHeightExtensions(start, end) {
-      const result = {};
-      for (let base = start; base <= end; base++) {
-        const px = base * 4;
-        for (let i = 1; i <= 3; i++) {
-          const upKey = `g${base}_up_${i}`;
-          const downKey = `g${base}_down_${i}`;
-          result[upKey] = toRem(px * Math.pow(phi, i));
-          result[downKey] = toRem(px / Math.pow(phi, i));
-        }
-      }
-      return result;
-    }
-    tailwind.config = {
-      theme: {
-        extend: {
-          height: {
-            ...goldenHeightExtensions(1, 64)
+    (function () {
+      const phi = 1.61803398875;
+      const toRem = px => `${(px / 16).toFixed(6)}rem`;
+
+      function goldenHeightExtensions(start, end) {
+        const result = {};
+        for (let base = start; base <= end; base++) {
+          const px = base * 4;
+          for (let i = 1; i <= 16; i++) {
+            const upKey = `g${base}_up_${i}`;
+            const downKey = `g${base}_down_${i}`;
+            result[upKey] = toRem(px * Math.pow(phi, i));
+            result[downKey] = toRem(px / Math.pow(phi, i));
           }
         }
+        return result;
       }
-    };
+
+      window.tailwind = window.tailwind || {};
+      window.tailwind.config = {
+        theme: {
+          extend: {
+            height: {
+              ...goldenHeightExtensions(1, 64)
+            }
+          }
+        }
+      };
+    })();
   </script>
   <script src="https://cdn.tailwindcss.com"></script>
 


### PR DESCRIPTION
## Summary
- refactor the inline Tailwind config to use an IIFE
- generate height utilities with up to 16 golden-ratio steps
- attach config to `window.tailwind` before loading Tailwind

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f4a83b50832baf55ce6dfb7d4a44