### PR TITLE
Add dynamic tag-filterable image gallery

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -1,1 +1,94 @@
+---
+layout: default
+title: "Gallery"
+subtitle: "Image Collection"
+---
 
+<div id="tag-filters" class="p-4 flex flex-wrap gap-4"></div>
+<div id="gallery" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 p-6"></div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  const rawData = [
+{% assign files = site.static_files | where_exp:"f","f.path contains '/assets/gallery/'" %}
+{% for f in files %}
+  {% assign ext = f.extname | downcase %}
+  {% if ext == '.png' or ext == '.jpg' or ext == '.jpeg' %}
+    {% assign rel = f.path | remove_first: 'assets/gallery/' %}
+    {% assign parts = rel | split: '/' %}
+    {% assign part_count = parts | size %}
+    {% assign last_index = part_count | minus: 1 %}
+    {% assign dirs = parts | slice: 0, last_index %}
+    {% assign file_name = parts[last_index] %}
+    {% assign name_no_ext = file_name | remove: ext %}
+    {% assign arr = name_no_ext | split: '_' %}
+    {% assign arr_size = arr | size %}
+    {% if arr_size > 1 %}
+      {% assign first_tag = arr[0] %}
+      {% assign title_arr = arr | slice: 1, arr_size | join: '_' %}
+      {% assign tags = dirs | push: first_tag %}
+    {% else %}
+      {% assign title_arr = name_no_ext %}
+      {% assign tags = dirs %}
+    {% endif %}
+    {"src": "{{ f.path | relative_url }}", "tags": {{ tags | jsonify }}, "title": {{ title_arr | jsonify }}, "batch": {{ dirs | join:'/' | jsonify }} }{% unless forloop.last %},{% endunless %}
+  {% endif %}
+{% endfor %}
+  ];
+  const groups = {};
+  rawData.forEach(item => {
+    if (!groups[item.batch]) groups[item.batch] = [];
+    groups[item.batch].push(item);
+  });
+  const shuffle = arr => {
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+  };
+  const batches = Object.values(groups);
+  batches.forEach(shuffle);
+  shuffle(batches);
+  const gallery = batches.flat();
+
+  const allTags = new Set();
+  gallery.forEach(img => img.tags.forEach(t => allTags.add(t)));
+  const filtersEl = document.getElementById('tag-filters');
+  allTags.forEach(tag => {
+    const label = document.createElement('label');
+    label.className = 'mr-4';
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.value = tag;
+    cb.className = 'mr-1';
+    cb.addEventListener('change', updateGallery);
+    label.appendChild(cb);
+    label.appendChild(document.createTextNode(tag));
+    filtersEl.appendChild(label);
+  });
+
+  const galleryEl = document.getElementById('gallery');
+  function updateGallery() {
+    const active = Array.from(filtersEl.querySelectorAll('input:checked')).map(cb => cb.value);
+    galleryEl.innerHTML = '';
+    gallery.forEach(item => {
+      if (active.length === 0 || item.tags.some(t => active.includes(t))) {
+        const figure = document.createElement('figure');
+        figure.className = 'mb-6';
+        const img = document.createElement('img');
+        img.src = item.src;
+        img.alt = item.title;
+        img.className = 'w-full h-auto rounded-lg shadow-md';
+        const cap = document.createElement('figcaption');
+        cap.textContent = item.title;
+        cap.className = 'text-center mt-1';
+        figure.appendChild(img);
+        figure.appendChild(cap);
+        galleryEl.appendChild(figure);
+      }
+    });
+  }
+
+  updateGallery();
+});
+</script>


### PR DESCRIPTION
## Summary
- build `gallery.html` page with front matter
- generate gallery metadata at build time using Liquid
- implement randomization and tag filtering in vanilla JS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855afc60b80832bb9c94f95f666e7de