### PR TITLE
Fix gallery modal image size

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -15,7 +15,8 @@ subtitle: "Image Collection"
       <div class="relative flex flex-col items-center">
         <div id="modal-title" class="mb-2 text-center"></div>
         <div id="modal-tags" class="flex gap-2 my-2 flex-wrap justify-center"></div>
-        <img id="modal-img" class="max-w-[95vw] max-h-[95vh] object-contain rounded-lg shadow-lg" loading="lazy">
+        <!-- Limit image size so title and tags remain visible -->
+        <img id="modal-img" class="max-w-[90vw] max-h-[80vh] object-contain rounded-lg shadow-lg" loading="lazy">
         <button id="prev-btn" class="absolute left-0 top-1/2 -translate-y-1/2 text-white text-4xl px-2" aria-label="Previous">&#10094;</button>
       <button id="next-btn" class="absolute right-0 top-1/2 -translate-y-1/2 text-white text-4xl px-2" aria-label="Next">&#10095;</button>
     </div>


### PR DESCRIPTION
## Summary
- ensure gallery modal images don't crowd out title or tags

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855cc75115c832b9643b43e46bf6479