### PR TITLE
Move inline CSS into single stylesheet

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -49,50 +49,7 @@
   </script>
   <script src="https://cdn.tailwindcss.com"></script>
 
-  <!-- **All your original inline CSS, unchanged** -->
-  <style>
-    body {
-      background-image: url('{{ "/images/background.png" | relative_url }}');
-      background-size: cover;
-      background-repeat: no-repeat;
-      background-attachment: fixed;
-      background-position: center;
-      color: #e8e4d8;
-      font-family: 'Georgia', serif;
-    }
-    .hover-image:hover img { filter: none; transform: scale(1.03); }
-    .hover-image img {
-      transition: all 1s ease;
-      filter: sepia(40%) brightness(85%) saturate(60%);
-      border-radius: 1rem;
-    }
-    .image-overlay {
-      position: absolute;
-      inset: 0;
-      background-color: rgba(27, 58, 26, 0.35);
-      border-radius: 1rem;
-      z-index: 1;
-      transition: background-color 0.5s ease;
-    }
-    .hover-image:hover .image-overlay { background-color: rgba(27, 58, 26, 0); }
-    .hover-text {
-      font-family: 'Georgia', serif;
-      font-size: 1.25rem;
-      color: #d7c49e;
-      text-shadow: 0 1px 2px rgba(0,0,0,0.7);
-      transition: transform 0.4s ease, font-size 0.4s ease, color 0.4s ease, text-shadow 0.4s ease;
-    }
-    .group:hover .hover-text         { transform: scale(1.08); }
-    .hover-text.light,
-    .hover-text.dark,
-    .hover-text.bluegreen            { color:#d7c49e; }
-    .group:hover .hover-text.light   { color:#1b3a1a;  text-shadow:0 0 10px rgba(0,0,0,.5);  font-weight:600; }
-    .group:hover .hover-text.dark    { color:#f2e2b3;  text-shadow:0 0 10px rgba(255,255,255,.6); font-weight:600; }
-    .group:hover .hover-text.bluegreen{ color:#641c34; text-shadow:0 0 14px rgba(50,10,20,.75); font-weight:600; }
-    .site-title  { font-family:'Cormorant Garamond', serif; color:#d7c49e; }
-    .menu-entry  { color:#d7c49e; font-family:'Georgia', serif; }
-    .menu-entry:hover { color:#e96f1f; }
-  </style>
+  <!-- site-wide styles moved to assets/css/site.css -->
 </head>
 
 <body class="bg-transparent">

--- a/_layouts/philosophy.html
+++ b/_layouts/philosophy.html
@@ -2,74 +2,7 @@
 layout: default
 ---
 
-<style>
-  :root {
-    --reader-bg:   #1e2a1e; /* deep olive */
-    --reader-text: #f1e9d2; /* warm ivory text */
-    --category-color: #f1e9d2cc; /* slightly muted variant of text color */
-    --reader-max-w: 56rem;
-    --reader-font-body: Georgia, serif;
-    --reader-font-title: "EB Garamond", serif;
-    --reader-font-size: 1rem;
-  }
-
-  .content-box {
-    background-color: var(--reader-bg);
-    color: var(--reader-text);
-    font-family: var(--reader-font-body);
-    font-size: var(--reader-font-size);
-    border-radius: 1rem;
-    padding: 2rem;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
-    max-width: var(--reader-max-w);
-  }
-
-  .content-box.edge-glow {
-    max-width: none;
-    width: 100%;
-  }
-
-  .content-inner {
-    max-width: var(--reader-max-w);
-    margin-left: auto;
-    margin-right: auto;
-  }
-
-  .content-box p {
-    line-height: 1.7;
-  }
-
-  .content-box h1,
-  .content-box h2,
-  .content-box h3,
-  .content-box h4,
-  .content-box h5,
-  .content-box h6 {
-    margin-top: 1.5rem;
-    font-weight: bold;
-    font-family: var(--reader-font-title);
-  }
-
-  /* indicator for active option in reader menu */
-  .option-btn {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-
-  .indicator {
-    width: 0.65rem;
-    height: 0.65rem;
-    border-radius: 50%;
-    background-color: var(--reader-text);
-  }
-
-  /* headings within the options menu and special buttons */
-  .option-category {
-    color: var(--category-color);
-    font-weight: bold;
-  }
-</style>
+<!-- styles now reside in assets/css/site.css -->
 
 <main class="content-box px-6 py-8 mx-auto relative">
   <button id="readerOptions" class="absolute top-2 right-2">
@@ -78,7 +11,7 @@ layout: default
   <div class="content-inner">
     {{ content }}
   </div>
-  <div id="optionsMenu" class="hidden absolute top-10 right-2 rounded-lg shadow-lg p-4 space-y-2" style="background:var(--reader-bg);color:var(--reader-text)">
+  <div id="optionsMenu" class="hidden absolute top-10 right-2 rounded-lg shadow-lg p-4 space-y-2">
     <button id="edgeGlowBtn" class="option-btn option-category block w-full text-left">Edge Glow Mode <span class="indicator hidden"></span></button>
     <div class="option-category">Color Scheme</div>
     <button data-scheme="olive" class="option-btn block w-full text-left">Olive <span class="indicator hidden"></span></button>
@@ -86,24 +19,24 @@ layout: default
     <button data-scheme="dark" class="option-btn block w-full text-left">Dark <span class="indicator hidden"></span></button>
     <button data-scheme="blue" class="option-btn block w-full text-left">Blue <span class="indicator hidden"></span></button>
     <button data-scheme="sepia" class="option-btn block w-full text-left">Sepia <span class="indicator hidden"></span></button>
-    <hr class="my-2 border-gray-600" style="border-color:var(--reader-text)">
+    <hr class="my-2 border-gray-600">
     <div class="option-category mt-3">Font Style</div>
     <button data-font="classic" class="option-btn block w-full text-left">Classic Serif <span class="indicator hidden"></span></button>
     <button data-font="modern" class="option-btn block w-full text-left">Modern Serif <span class="indicator hidden"></span></button>
     <button data-font="humanist" class="option-btn block w-full text-left">Humanist Sans <span class="indicator hidden"></span></button>
     <button data-font="mono" class="option-btn block w-full text-left">Literary Monospace <span class="indicator hidden"></span></button>
-    <hr class="my-2 border-gray-600" style="border-color:var(--reader-text)">
+    <hr class="my-2 border-gray-600">
     <div class="option-category mt-3">Font Size</div>
     <button data-fsize="small"   class="option-btn block w-full text-left">Small <span class="indicator hidden"></span></button>
     <button data-fsize="default" class="option-btn block w-full text-left">Default <span class="indicator hidden"></span></button>
     <button data-fsize="large"   class="option-btn block w-full text-left">Large <span class="indicator hidden"></span></button>
     <button data-fsize="huge"    class="option-btn block w-full text-left">Huge <span class="indicator hidden"></span></button>
-    <hr class="my-2 border-gray-600" style="border-color:var(--reader-text)">
+    <hr class="my-2 border-gray-600">
     <div class="option-category mt-3">Reader Size</div>
     <button data-size="narrow" class="option-btn block w-full text-left">Narrow <span class="indicator hidden"></span></button>
     <button data-size="medium" class="option-btn block w-full text-left">Medium <span class="indicator hidden"></span></button>
     <button data-size="wide" class="option-btn block w-full text-left">Wide <span class="indicator hidden"></span></button>
-    <hr class="my-2 border-gray-600" style="border-color:var(--reader-text)">
+    <hr class="my-2 border-gray-600">
     <button id="resetOptions" class="option-category block w-full text-left mt-2">Reset</button>
   </div>
 </main>

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -1,3 +1,6 @@
+---
+---
+
 /* Branding & nav colours (shared with header include) */
   .site-title  { font-family: 'Cormorant Garamond', serif; color:#d7c49e; }
   .menu-entry  { color:#d7c49e; font-family:'Georgia', serif; }
@@ -44,8 +47,190 @@
     cursor: pointer;
   }
   
-    #modal-title {
+  #modal-title {
     margin-bottom: 0.5rem;
     text-align: center;
     font-size: 1.125rem;
   }
+
+/* Global background and hover effects from default layout */
+body {
+  background-image: url('{{ '/images/background.png' | relative_url }}');
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  background-position: center;
+  color: #e8e4d8;
+  font-family: 'Georgia', serif;
+}
+
+.hover-image:hover img { filter: none; transform: scale(1.03); }
+.hover-image img {
+  transition: all 1s ease;
+  filter: sepia(40%) brightness(85%) saturate(60%);
+  border-radius: 1rem;
+}
+.image-overlay {
+  position: absolute;
+  inset: 0;
+  background-color: rgba(27, 58, 26, 0.35);
+  border-radius: 1rem;
+  z-index: 1;
+  transition: background-color 0.5s ease;
+}
+.hover-image:hover .image-overlay { background-color: rgba(27, 58, 26, 0); }
+.hover-text {
+  font-family: 'Georgia', serif;
+  font-size: 1.25rem;
+  color: #d7c49e;
+  text-shadow: 0 1px 2px rgba(0,0,0,0.7);
+  transition: transform 0.4s ease, font-size 0.4s ease, color 0.4s ease, text-shadow 0.4s ease;
+}
+.group:hover .hover-text { transform: scale(1.08); }
+.hover-text.light,
+.hover-text.dark,
+.hover-text.bluegreen { color:#d7c49e; }
+.group:hover .hover-text.light   { color:#1b3a1a;  text-shadow:0 0 10px rgba(0,0,0,.5);  font-weight:600; }
+.group:hover .hover-text.dark    { color:#f2e2b3;  text-shadow:0 0 10px rgba(255,255,255,.6); font-weight:600; }
+.group:hover .hover-text.bluegreen{ color:#641c34; text-shadow:0 0 14px rgba(50,10,20,.75); font-weight:600; }
+
+/* Philosophy reader layout styles */
+:root {
+  --reader-bg:   #1e2a1e;
+  --reader-text: #f1e9d2;
+  --category-color: #f1e9d2cc;
+  --reader-max-w: 56rem;
+  --reader-font-body: Georgia, serif;
+  --reader-font-title: 'EB Garamond', serif;
+  --reader-font-size: 1rem;
+}
+
+.content-box {
+  background-color: var(--reader-bg);
+  color: var(--reader-text);
+  font-family: var(--reader-font-body);
+  font-size: var(--reader-font-size);
+  border-radius: 1rem;
+  padding: 2rem;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+  max-width: var(--reader-max-w);
+}
+
+.content-box.edge-glow {
+  max-width: none;
+  width: 100%;
+}
+
+.content-inner {
+  max-width: var(--reader-max-w);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.content-box p { line-height: 1.7; }
+
+.content-box h1,
+.content-box h2,
+.content-box h3,
+.content-box h4,
+.content-box h5,
+.content-box h6 {
+  margin-top: 1.5rem;
+  font-weight: bold;
+  font-family: var(--reader-font-title);
+}
+
+/* indicator for active option in reader menu */
+.option-btn {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.indicator {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  background-color: var(--reader-text);
+}
+
+/* headings within the options menu and special buttons */
+.option-category {
+  color: var(--category-color);
+  font-weight: bold;
+}
+
+/* page‑specific image styling for philosophy overview */
+.entry-image {
+  width: 70%;
+  height: auto;
+  border-radius: 0.75rem;
+  box-shadow: 0 4px 8px rgba(0,0,0,.35);
+}
+
+/* Tag gallery styles */
+#tag-filters label,
+#modal-tags label {
+  display: flex;
+  align-items: center;
+  margin-right: 0.5rem;
+}
+
+input.tag-checkbox {
+  appearance: none;
+  width: 1rem;
+  height: 1rem;
+  margin-right: 0.25rem;
+  border-radius: 0.25rem;
+  border: 1px solid #d7c49e;
+  background-color: #d7c49e;
+  position: relative;
+  cursor: pointer;
+}
+
+input.tag-checkbox:checked { background-color: #e96f1f; }
+
+input.tag-checkbox:checked::after {
+  content: '\2713';
+  position: absolute;
+  top: -0.1rem;
+  left: 0.18rem;
+  color: #1e1e1e;
+  font-size: 0.75rem;
+}
+
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 4px;
+  padding: 4px;
+}
+
+@media (min-width: 640px) {
+  .gallery { grid-template-columns: repeat(3, 1fr); }
+}
+
+@media (min-width: 1024px) {
+  .gallery { grid-template-columns: repeat(5, 1fr); }
+}
+
+.tile {
+  position: relative;
+  width: 100%;
+  padding-top: 100%;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.tile img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* Option menu default colors */
+#optionsMenu { background: var(--reader-bg); color: var(--reader-text); }
+#optionsMenu hr { border-color: var(--reader-text); }

--- a/gallery.html
+++ b/gallery.html
@@ -6,7 +6,7 @@ subtitle: "Image Collection"
 
 <div id="tag-filters" class="p-4 flex flex-wrap gap-4 justify-center"></div>
 <div id="gallery" class="gallery"></div>
-<div id="image-modal" class="fixed inset-0 bg-black/70 hidden z-50 flex items-center justify-center p-4 backdrop-blur-md" style="background-image: url('{{ '/images/background.png' | relative_url }}'); background-size: cover; background-position: center;">
+<div id="image-modal" class="fixed inset-0 bg-black/70 hidden z-50 flex items-center justify-center p-4 backdrop-blur-md">
   <button id="close-modal" class="absolute top-4 right-4 text-3xl text-white">&times;</button>
   <div class="flex items-center gap-2 w-full justify-between">
     <div id="prev-preview" class="preview cursor-pointer hidden md:block">
@@ -27,84 +27,7 @@ subtitle: "Image Collection"
   </div>
 </div>
 
-<style>
-  #tag-filters label,
-  #modal-tags label {
-    display: flex;
-    align-items: center;
-    margin-right: 0.5rem;
-  }
 
-  input.tag-checkbox {
-    appearance: none;
-    width: 1rem;
-    height: 1rem;
-    margin-right: 0.25rem;
-    border-radius: 0.25rem;
-    border: 1px solid #d7c49e;
-    background-color: #d7c49e;
-    position: relative;
-    cursor: pointer;
-  }
-
-  input.tag-checkbox:checked {
-    background-color: #e96f1f;
-  }
-
-  input.tag-checkbox:checked::after {
-    content: '\2713';
-    position: absolute;
-    top: -0.1rem;
-    left: 0.18rem;
-    color: #1e1e1e;
-    font-size: 0.75rem;
-  }
-
-  .gallery {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 4px;
-    padding: 4px;
-  }
-
-  @media (min-width: 640px) {
-    .gallery {
-      grid-template-columns: repeat(3, 1fr);
-    }
-  }
-
-  @media (min-width: 1024px) {
-    .gallery {
-      grid-template-columns: repeat(5, 1fr);
-    }
-  }
-
-  .tile {
-    position: relative;
-    width: 100%;
-    padding-top: 100%;
-    overflow: hidden;
-    cursor: pointer;
-  }
-
-  .tile img {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
-
-
- 
-
-
-
-
-
-
-</style>
 
 <script>
 document.addEventListener('DOMContentLoaded', function () {

--- a/index.html
+++ b/index.html
@@ -4,44 +4,6 @@ title: "Sympnoia"
 subtitle: "Breathing Together: An Ethical Framework for Shared Existence"
 ---
 
-<style>
-  /* Hover‑image panel styles (kept from the original file) */
-  .hover-image:hover img {
-    filter: none;
-    transform: scale(1.03);
-  }
-  .hover-image img {
-    transition: all 1s ease;
-    filter: sepia(40%) brightness(85%) saturate(60%);
-    border-radius: 1rem;
-  }
-  .image-overlay {
-    position: absolute;
-    inset: 0;
-    background-color: rgba(27, 58, 26, 0.35);
-    border-radius: 1rem;
-    z-index: 1;
-    transition: background-color 0.5s ease;
-  }
-  .hover-image:hover .image-overlay { background-color: rgba(27, 58, 26, 0); }
-
-  /* Optional text‑overlay animations (unused right now, preserved for future use) */
-  .hover-text {
-    font-family: 'Georgia', serif;
-    font-size: 1.25rem;
-    color: #d7c49e;
-    text-shadow: 0 1px 2px rgba(0,0,0,0.7);
-    transition: transform 0.4s ease, font-size 0.4s ease, color 0.4s ease, text-shadow 0.4s ease;
-  }
-  .group:hover .hover-text { transform: scale(1.08); }
-  .hover-text.light, .hover-text.dark, .hover-text.bluegreen { color: #d7c49e; }
-  .group:hover .hover-text.light   { color:#1b3a1a; text-shadow: 0 0 10px rgba(0,0,0,0.5);  font-weight:600; }
-  .group:hover .hover-text.dark    { color:#f2e2b3; text-shadow: 0 0 10px rgba(255,255,255,0.6); font-weight:600; }
-  .group:hover .hover-text.bluegreen { color:#641c34; text-shadow: 0 0 14px rgba(50,10,20,0.75); font-weight:600; }
-
-
-</style>
-
 <main class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 p-6">
   <a href="writings.html" class="hover-image group block relative max-w-md mx-auto">
     <img src="images/Writings.png" alt="Writings" class="w-full h-auto shadow-md">

--- a/philosophy.html
+++ b/philosophy.html
@@ -4,16 +4,6 @@ title: "Philosophy"
 subtitle: "Explorations of Ground, Being, and Shared Reality"
 ---
 
-<style>
-  /* page‑specific image styling */
-  .entry-image {
-    width: 70%;
-    height: auto;
-    border-radius: 0.75rem;
-    box-shadow: 0 4px 8px rgba(0,0,0,.35);
-  }
-</style>
-
 <main class="max-w-6xl mx-auto px-6 pb-20 space-y-24">
 {% for post in site.philosophy %}
   {% assign odd = forloop.index0 | modulo: 2 %}


### PR DESCRIPTION
## Summary
- consolidate all inline styles into `assets/css/site.css`
- remove redundant `<style>` tags and inline attributes from layouts and pages
- enable Liquid processing for `site.css` to keep relative URLs working

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68598879ff00832b8a84ef0d1fba5440