### PR TITLE
Add blog page with tag filtering

### DIFF
--- a/assets/js/tag-filter.js
+++ b/assets/js/tag-filter.js
@@ -1,0 +1,67 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const filterBar = document.getElementById('tag-filter');
+  const posts = Array.from(document.querySelectorAll('.blog-post'));
+
+  const tagSet = new Set();
+  posts.forEach(p => {
+    const tags = p.dataset.tags ? p.dataset.tags.split(',') : [];
+    tags.forEach(t => tagSet.add(t));
+  });
+
+  const createBtn = (tag, label) => {
+    const b = document.createElement('button');
+    b.textContent = label || tag;
+    b.dataset.tag = tag;
+    b.className = 'tag-btn px-3 py-1 rounded-full bg-[#d7c49e] text-[#1e1e1e] text-sm';
+    return b;
+  };
+
+  const allBtn = createBtn('', 'All');
+  allBtn.classList.add('font-semibold');
+  filterBar.appendChild(allBtn);
+
+  Array.from(tagSet).sort().forEach(t => filterBar.appendChild(createBtn(t)));
+
+  let active = '';
+
+  function setActive(btn) {
+    filterBar.querySelectorAll('button').forEach(b => b.classList.remove('bg-[#e96f1f]','text-white'));
+    if (btn) btn.classList.add('bg-[#e96f1f]', 'text-white');
+  }
+
+  function showPost(p) {
+    p.classList.remove('hidden', 'opacity-0');
+    p.classList.add('opacity-100');
+  }
+
+  function hidePost(p) {
+    p.classList.add('opacity-0');
+    setTimeout(() => p.classList.add('hidden'), 300);
+  }
+
+  function filterPosts() {
+    posts.forEach(p => {
+      if (!active || p.dataset.tags.includes(active)) {
+        showPost(p);
+      } else {
+        hidePost(p);
+      }
+    });
+  }
+
+  filterBar.addEventListener('click', e => {
+    if (!e.target.dataset.tag) return;
+    active = e.target.dataset.tag;
+    setActive(e.target);
+    filterPosts();
+  });
+
+  document.getElementById('post-list').addEventListener('click', e => {
+    if (e.target.classList.contains('tag')) {
+      active = e.target.dataset.tag;
+      const btn = filterBar.querySelector(`button[data-tag="${active}"]`);
+      setActive(btn);
+      filterPosts();
+    }
+  });
+});

--- a/blog.html
+++ b/blog.html
@@ -1,1 +1,36 @@
+---
+layout: default
+title: "Blog"
+subtitle: "Thoughts & Updates"
+---
 
+<div id="tag-filter" class="flex flex-wrap gap-2 justify-center mb-6"></div>
+
+<main id="post-list" class="max-w-4xl mx-auto px-6 space-y-12">
+  {% assign posts = site.posts | where_exp:"p","p.tags" %}
+  {% for post in posts %}
+  <article class="blog-post flex flex-col md:flex-row gap-6 transition-opacity opacity-100" data-tags="{{ post.tags | join: ',' }}">
+    <a href="{{ post.url | relative_url }}" class="md:w-48 flex-shrink-0">
+      {% if post.preview_image %}
+      <img src="{{ post.preview_image | relative_url }}" alt="Preview image for {{ post.title }}" class="w-full h-auto rounded-lg shadow-md">
+      {% else %}
+      <img src="{{ '/images/Blog.png' | relative_url }}" alt="Preview image placeholder" class="w-full h-auto rounded-lg shadow-md">
+      {% endif %}
+    </a>
+    <div>
+      <h2 class="text-2xl font-bold mb-1"><a href="{{ post.url | relative_url }}" class="hover:underline">{{ post.title }}</a></h2>
+      <p class="text-sm text-gray-400 mb-2">{{ post.date | date: '%B %-d, %Y' }}</p>
+      <p class="mb-4">{{ post.excerpt | strip_html | truncate: 160 }}</p>
+      {% if post.tags %}
+      <div class="post-tags flex flex-wrap gap-2">
+        {% for tag in post.tags %}
+        <span class="tag px-2 py-1 rounded-full bg-[#d7c49e] text-[#1e1e1e] text-sm cursor-pointer" data-tag="{{ tag }}">{{ tag }}</span>
+        {% endfor %}
+      </div>
+      {% endif %}
+    </div>
+  </article>
+  {% endfor %}
+</main>
+
+<script src="{{ '/assets/js/tag-filter.js' | relative_url }}"></script>


### PR DESCRIPTION
## Summary
- create blog page to list posts with tag badges
- add simple tag filter bar via JS

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a8aa837d8832b900a96a454694a51