### PR TITLE
Update gallery filters to use buttons

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -190,36 +190,6 @@ body {
   box-shadow: 0 4px 8px rgba(0,0,0,.35);
 }
 
-/* Tag gallery styles */
-#tag-filters label,
-#modal-tags label {
-  display: flex;
-  align-items: center;
-  margin-right: 0.5rem;
-}
-
-input.tag-checkbox {
-  appearance: none;
-  width: 1rem;
-  height: 1rem;
-  margin-right: 0.25rem;
-  border-radius: 0.25rem;
-  border: 1px solid #d7c49e;
-  background-color: #d7c49e;
-  position: relative;
-  cursor: pointer;
-}
-
-input.tag-checkbox:checked { background-color: #e96f1f; }
-
-input.tag-checkbox:checked::after {
-  content: '\2713';
-  position: absolute;
-  top: -0.1rem;
-  left: 0.18rem;
-  color: #1e1e1e;
-  font-size: 0.75rem;
-}
 
 .gallery {
   display: grid;

--- a/gallery.html
+++ b/gallery.html
@@ -87,18 +87,33 @@ document.addEventListener('DOMContentLoaded', function () {
   gallery.forEach(img => img.tags.forEach(t => allTags.add(t)));
   const filtersEl = document.getElementById('tag-filters');
 
-  Array.from(allTags).sort().forEach(tag => {
-    const label = document.createElement('label');
-    const cb = document.createElement('input');
-    cb.type = 'checkbox';
-    cb.value = tag;
-    cb.className = 'tag-checkbox';
-    label.appendChild(cb);
-    label.appendChild(document.createTextNode(tag));
-    filtersEl.appendChild(label);
-  });
+  const createBtn = tag => {
+    const b = document.createElement('button');
+    b.textContent = tag;
+    b.dataset.tag = tag;
+    b.className = 'tag-btn px-3 py-1 rounded-full bg-[#d7c49e] text-[#1e1e1e] text-sm';
+    return b;
+  };
 
-  filtersEl.addEventListener('change', updateGallery);
+  Array.from(allTags)
+    .filter(t => t)
+    .sort()
+    .forEach(tag => filtersEl.appendChild(createBtn(tag)));
+
+  const activeTags = new Set();
+
+  filtersEl.addEventListener('click', e => {
+    if (!e.target.dataset.tag) return;
+    const tag = e.target.dataset.tag;
+    if (activeTags.has(tag)) {
+      activeTags.delete(tag);
+      e.target.classList.remove('bg-[#e96f1f]', 'text-white');
+    } else {
+      activeTags.add(tag);
+      e.target.classList.add('bg-[#e96f1f]', 'text-white');
+    }
+    updateGallery();
+  });
 
   const galleryEl = document.getElementById('gallery');
   const modal = document.getElementById('image-modal');
@@ -115,7 +130,7 @@ document.addEventListener('DOMContentLoaded', function () {
   let currentIndex = 0;
 
   function updateGallery() {
-    const active = Array.from(filtersEl.querySelectorAll('input.tag-checkbox:checked')).map(cb => cb.value);
+    const active = Array.from(activeTags);
     galleryEl.innerHTML = '';
     visibleItems = active.length === 0 ? gallery : gallery.filter(item => item.tags.some(t => active.includes(t)));
     visibleItems.forEach((item, idx) => {
@@ -139,15 +154,11 @@ document.addEventListener('DOMContentLoaded', function () {
     if (modalTags) {
       modalTags.innerHTML = '';
       item.tags.forEach(t => {
-        const l = document.createElement('label');
-        const c = document.createElement('input');
-        c.type = 'checkbox';
-        c.checked = true;
-        c.disabled = true;
-        c.className = 'tag-checkbox';
-        l.appendChild(c);
-        l.appendChild(document.createTextNode(t));
-        modalTags.appendChild(l);
+        const b = document.createElement('button');
+        b.textContent = t;
+        b.className = 'tag-btn px-3 py-1 rounded-full bg-[#d7c49e] text-[#1e1e1e] text-sm';
+        b.disabled = true;
+        modalTags.appendChild(b);
       });
     }
     const prevIndex = (currentIndex - 1 + visibleItems.length) % visibleItems.length;


### PR DESCRIPTION
## Summary
- swap checkbox filters for buttons in gallery
- generate modal tag buttons
- remove checkbox styling from CSS

## Testing
- `npm test` *(fails: missing script)*
- `npx @openai/codex test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_685bf7f2e220832b984cdac773d1cfc7