### PR TITLE
Fix label support for gallery controls

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -98,9 +98,9 @@ document.addEventListener('DOMContentLoaded', function () {
   const filtersEl = document.getElementById('tag-filters');
   const controlsEl = document.getElementById('tag-controls');
 
-  const createBtn = tag => {
+  const createBtn = (tag, label) => {
     const b = document.createElement('button');
-    b.textContent = tag;
+    b.textContent = label || tag;
     b.dataset.tag = tag;
     b.className = 'tag-btn px-3 py-1 rounded-full bg-[#d7c49e] text-[#1e1e1e] text-sm';
     return b;


### PR DESCRIPTION
## Summary
- add `label` argument to `createBtn`
- ensure reset and invert buttons display their text

## Testing
- `npm test` *(fails: Missing script)*
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c1564be58832bb4a63722d80302b8