### PR TITLE
Refactor tag filtering logic

### DIFF
--- a/assets/js/tag-filter.js
+++ b/assets/js/tag-filter.js
@@ -1,107 +1,111 @@
-// Multi-select tag filtering for blog posts with reset and invert controls
-
-document.addEventListener('DOMContentLoaded', () => {
-  const filterBar = document.getElementById('tag-filter');
-  const controlBar = document.getElementById('tag-controls');
-  const posts = Array.from(document.querySelectorAll('.blog-post'));
-
-  const tagSet = new Set();
-  posts.forEach(p => {
-    const tags = p.dataset.tags ? p.dataset.tags.split(',') : [];
-    tags.forEach(t => tagSet.add(t));
-  });
-
-  const createBtn = (tag, label, extra) => {
-    const b = document.createElement('button');
-    b.textContent = label || tag;
-    if (tag) b.dataset.tag = tag;
-    b.className = extra || 'tag-btn px-3 py-1 rounded-full bg-[#d7c49e] text-[#1e1e1e] text-sm';
-    return b;
-  };
-
-  const resetBtn = createBtn('', 'Reset', 'px-3 py-1 rounded-full bg-[#d7c49e] text-[#1e1e1e] text-sm font-semibold');
-  const invertBtn = createBtn('', 'Invert', 'px-3 py-1 rounded-full bg-[#d7c49e] text-[#1e1e1e] text-sm font-semibold');
-  if (controlBar) {
-    controlBar.appendChild(resetBtn);
-    controlBar.appendChild(invertBtn);
-  }
-
-  Array.from(tagSet).sort().forEach(t => filterBar.appendChild(createBtn(t)));
-
-  const activeTags = new Set();
-
-  function updateButtons() {
-    filterBar.querySelectorAll('button[data-tag]').forEach(btn => {
-      if (activeTags.has(btn.dataset.tag)) {
-        btn.classList.add('bg-[#e96f1f]', 'text-white');
-      } else {
-        btn.classList.remove('bg-[#e96f1f]', 'text-white');
-      }
-    });
-  }
-
-  function showPost(p) {
-    p.classList.remove('hidden', 'opacity-0');
-    p.classList.add('opacity-100');
-  }
-
-  function hidePost(p) {
-    p.classList.add('opacity-0');
-    setTimeout(() => p.classList.add('hidden'), 300);
-  }
-
-  function filterPosts() {
-    const active = Array.from(activeTags);
-    posts.forEach(p => {
-      const tags = p.dataset.tags ? p.dataset.tags.split(',') : [];
-      const match = active.length === 0 || active.some(t => tags.includes(t));
-      if (match) {
-        showPost(p);
-      } else {
-        hidePost(p);
-      }
-    });
-  }
-
-  filterBar.addEventListener('click', e => {
-    if (!e.target.dataset.tag) return;
-    const tag = e.target.dataset.tag;
-    if (activeTags.has(tag)) {
-      activeTags.delete(tag);
-    } else {
-      activeTags.add(tag);
+(function(global){
+  function initTagFilter(filterId, controlId, opts={}){
+    const filterBar = document.getElementById(filterId);
+    const controlBar = document.getElementById(controlId);
+    const items = opts.items ? Array.from(opts.items) : null;
+    const onChange = typeof opts.onChange === 'function' ? opts.onChange : null;
+    const tagSet = new Set(opts.tags || []);
+    if (items){
+      items.forEach(p => {
+        const tags = p.dataset.tags ? p.dataset.tags.split(',') : [];
+        tags.forEach(t => tagSet.add(t));
+      });
     }
-    updateButtons();
-    filterPosts();
-  });
 
-  document.getElementById('post-list').addEventListener('click', e => {
-    if (e.target.classList.contains('tag')) {
-      const tag = e.target.dataset.tag;
-      if (activeTags.has(tag)) {
-        activeTags.delete(tag);
-      } else {
-        activeTags.add(tag);
+    const createBtn = (tag,label,extra)=>{
+      const b=document.createElement('button');
+      b.textContent=label||tag;
+      if(tag) b.dataset.tag=tag;
+      b.className=extra||'tag-btn px-3 py-1 rounded-full bg-[#d7c49e] text-[#1e1e1e] text-sm';
+      return b;
+    };
+
+    const resetBtn=createBtn('', 'Reset', 'px-3 py-1 rounded-full bg-[#d7c49e] text-[#1e1e1e] text-sm font-semibold');
+    const invertBtn=createBtn('', 'Invert', 'px-3 py-1 rounded-full bg-[#d7c49e] text-[#1e1e1e] text-sm font-semibold');
+    if(controlBar){
+      controlBar.appendChild(resetBtn);
+      controlBar.appendChild(invertBtn);
+    }
+
+    Array.from(tagSet).filter(t=>t).sort().forEach(t=>filterBar.appendChild(createBtn(t)));
+
+    const activeTags=new Set();
+
+    function updateButtons(){
+      filterBar.querySelectorAll('button[data-tag]').forEach(btn=>{
+        if(activeTags.has(btn.dataset.tag)){
+          btn.classList.add('bg-[#e96f1f]','text-white');
+        }else{
+          btn.classList.remove('bg-[#e96f1f]','text-white');
+        }
+      });
+    }
+
+    function showItem(p){
+      p.classList.remove('hidden','opacity-0');
+      p.classList.add('opacity-100');
+    }
+
+    function hideItem(p){
+      p.classList.add('opacity-0');
+      setTimeout(()=>p.classList.add('hidden'),300);
+    }
+
+    function applyFilter(){
+      if(items){
+        const active=Array.from(activeTags);
+        items.forEach(p=>{
+          const tags=p.dataset.tags?p.dataset.tags.split(','):[];
+          const match=active.length===0||active.some(t=>tags.includes(t));
+          if(match){
+            showItem(p);
+          }else{
+            hideItem(p);
+          }
+        });
       }
+      if(onChange) onChange(Array.from(activeTags));
+    }
+
+    filterBar.addEventListener('click',e=>{
+      if(!e.target.dataset.tag) return;
+      const tag=e.target.dataset.tag;
+      if(activeTags.has(tag)) activeTags.delete(tag); else activeTags.add(tag);
       updateButtons();
-      filterPosts();
-    }
-  });
-
-  resetBtn.addEventListener('click', () => {
-    activeTags.clear();
-    updateButtons();
-    filterPosts();
-  });
-
-  invertBtn.addEventListener('click', () => {
-    const newActive = new Set();
-    tagSet.forEach(t => {
-      if (!activeTags.has(t)) newActive.add(t);
+      applyFilter();
     });
-    activeTags.clear();
-    newActive.forEach(t => activeTags.add(t));
-    updateButtons();
-    filterPosts();
-  });
-});
+
+    const postList=document.getElementById('post-list');
+    if(postList){
+      postList.addEventListener('click',e=>{
+        if(e.target.classList.contains('tag')){
+          const tag=e.target.dataset.tag;
+          if(activeTags.has(tag)) activeTags.delete(tag); else activeTags.add(tag);
+          updateButtons();
+          applyFilter();
+        }
+      });
+    }
+
+    resetBtn.addEventListener('click',()=>{
+      activeTags.clear();
+      updateButtons();
+      applyFilter();
+    });
+
+    invertBtn.addEventListener('click',()=>{
+      const newActive=new Set();
+      tagSet.forEach(t=>{if(!activeTags.has(t)) newActive.add(t);});
+      activeTags.clear();
+      newActive.forEach(t=>activeTags.add(t));
+      updateButtons();
+      applyFilter();
+    });
+
+    applyFilter();
+
+    return {activeTags};
+  }
+
+  global.initTagFilter=initTagFilter;
+})(window);

--- a/blog.html
+++ b/blog.html
@@ -35,3 +35,9 @@ subtitle: "Thoughts & Updates"
 </main>
 
 <script src="{{ '/assets/js/tag-filter.js' | relative_url }}"></script>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const posts = document.querySelectorAll('.blog-post');
+  initTagFilter('tag-filter', 'tag-controls', { items: posts });
+});
+</script>

--- a/gallery.html
+++ b/gallery.html
@@ -30,6 +30,7 @@ subtitle: "Image Collection"
 
 
 
+<script src="{{ "/assets/js/tag-filter.js" | relative_url }}"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function () {
   const rawData = [
@@ -95,69 +96,6 @@ document.addEventListener('DOMContentLoaded', function () {
 
   const allTags = new Set();
   gallery.forEach(img => img.tags.forEach(t => allTags.add(t)));
-  const filtersEl = document.getElementById('tag-filters');
-  const controlsEl = document.getElementById('tag-controls');
-
-  const createBtn = (tag, label) => {
-    const b = document.createElement('button');
-    b.textContent = label || tag;
-    b.dataset.tag = tag;
-    b.className = 'tag-btn px-3 py-1 rounded-full bg-[#d7c49e] text-[#1e1e1e] text-sm';
-    return b;
-  };
-
-  Array.from(allTags)
-    .filter(t => t)
-    .sort()
-    .forEach(tag => filtersEl.appendChild(createBtn(tag)));
-
-  const resetBtn = createBtn('', 'Reset');
-  resetBtn.classList.add('font-semibold', 'bg-[#d7c49e]');
-  const invertBtn = createBtn('', 'Invert');
-  invertBtn.classList.add('font-semibold', 'bg-[#d7c49e]');
-  controlsEl.appendChild(resetBtn);
-  controlsEl.appendChild(invertBtn);
-
-  const activeTags = new Set();
-
-  filtersEl.addEventListener('click', e => {
-    if (!e.target.dataset.tag) return;
-    const tag = e.target.dataset.tag;
-    if (activeTags.has(tag)) {
-      activeTags.delete(tag);
-      e.target.classList.remove('bg-[#e96f1f]', 'text-white');
-    } else {
-      activeTags.add(tag);
-      e.target.classList.add('bg-[#e96f1f]', 'text-white');
-    }
-    updateGallery();
-  });
-
-  resetBtn.addEventListener('click', () => {
-    activeTags.clear();
-    filtersEl.querySelectorAll('button').forEach(b =>
-      b.classList.remove('bg-[#e96f1f]', 'text-white')
-    );
-    updateGallery();
-  });
-
-  invertBtn.addEventListener('click', () => {
-    const newActive = new Set();
-    allTags.forEach(t => {
-      if (!activeTags.has(t)) newActive.add(t);
-    });
-    activeTags.clear();
-    filtersEl.querySelectorAll('button').forEach(b => {
-      const tag = b.dataset.tag;
-      if (newActive.has(tag)) {
-        activeTags.add(tag);
-        b.classList.add('bg-[#e96f1f]', 'text-white');
-      } else {
-        b.classList.remove('bg-[#e96f1f]', 'text-white');
-      }
-    });
-    updateGallery();
-  });
 
   const galleryEl = document.getElementById('gallery');
   const modal = document.getElementById('image-modal');
@@ -170,11 +108,12 @@ document.addEventListener('DOMContentLoaded', function () {
   const prevPreview = document.querySelector('#prev-preview img');
   const nextPreview = document.querySelector('#next-preview img');
 
+  const tagFilter = initTagFilter("tag-filters", "tag-controls", { tags: Array.from(allTags), onChange: updateGallery });
   let visibleItems = [];
   let currentIndex = 0;
 
   function updateGallery() {
-    const active = Array.from(activeTags);
+    const active = Array.from(tagFilter.activeTags);
     galleryEl.innerHTML = '';
     let items = [];
     if (active.length === 0) {


### PR DESCRIPTION
## Summary
- move tag filter logic into a reusable `initTagFilter`
- use the new helper in `blog.html`
- replace inline filter code in `gallery.html`

## Testing
- `npx @openai/codex test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_685c1eabeb94832b907f9f5da3d99bf9