### PR TITLE
Display glossary with reader layout and highlight links

### DIFF
--- a/_layouts/reader.html
+++ b/_layouts/reader.html
@@ -145,6 +145,8 @@ layout: default
     document.documentElement.style.setProperty('--reader-text', s.text);
     const cat = mixColor(s.text, s.bg, 0.7);
     document.documentElement.style.setProperty('--category-color', cat);
+    const link = mixColor(s.text, s.bg, 0.4);
+    document.documentElement.style.setProperty('--reader-link', link);
     storageSet('readerScheme', name);
     updateIndicator('[data-scheme]', 'scheme', name);
   }

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -99,6 +99,7 @@ body {
   --reader-bg:   #1e2a1e;
   --reader-text: #f1e9d2;
   --category-color: #f1e9d2cc;
+  --reader-link: #9fc5ff;
   --reader-max-w: 56rem;
   --reader-font-body: Georgia, serif;
   --reader-font-title: 'EB Garamond', serif;
@@ -127,7 +128,15 @@ body {
   margin-right: auto;
 }
 
-.content-box p { line-height: 1.7; }
+.content-box p {
+  line-height: 1.7;
+  margin-bottom: 3rem;
+}
+
+.content-box a {
+  color: var(--reader-link);
+  text-decoration: underline;
+}
 
 .content-box h1,
 .content-box h2,

--- a/glossary.md
+++ b/glossary.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: reader
 title: Glossary
 ---
 
@@ -20,6 +20,8 @@ title: Glossary
 * [Self](#h.k5f67shf1uqd)
 * [World](#h.xlnhw1e1mvjn)
 * [Yin-Yang (☯)](#h.l1d8ogrz7f6r)
+
+<br><br><br><br><br>
 
 ---
 


### PR DESCRIPTION
## Summary
- switch the glossary page to the reader layout
- visibly separate Table of Contents from the rest
- add link styling and extra spacing between paragraphs
- adjust colour scheme logic to set a link colour

## Testing
- `npm test` *(fails: Missing script)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e70d12450832bae3d91ec7e0e8633