### PR TITLE
Improve reader typography

### DIFF
--- a/_layouts/reader.html
+++ b/_layouts/reader.html
@@ -145,8 +145,17 @@ layout: default
     document.documentElement.style.setProperty('--reader-text', s.text);
     const cat = mixColor(s.text, s.bg, 0.7);
     document.documentElement.style.setProperty('--category-color', cat);
-    const link = mixColor(s.text, s.bg, 0.4);
+
+    const title = name === 'olive'
+      ? '#d7c49e'
+      : mixColor(s.text, s.bg, 0.75);
+    document.documentElement.style.setProperty('--reader-title', title);
+
+    const link = name === 'olive'
+      ? '#9a6000'
+      : mixColor('#9a6000', s.text, 0.55);
     document.documentElement.style.setProperty('--reader-link', link);
+
     storageSet('readerScheme', name);
     updateIndicator('[data-scheme]', 'scheme', name);
   }

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -99,11 +99,12 @@ body {
   --reader-bg:   #1e2a1e;
   --reader-text: #f1e9d2;
   --category-color: #f1e9d2cc;
-  --reader-link: #9fc5ff;
+  --reader-link: #9a6000;
   --reader-max-w: 56rem;
   --reader-font-body: Georgia, serif;
   --reader-font-title: 'EB Garamond', serif;
   --reader-font-size: 1rem;
+  --reader-title: #d7c49e;
 }
 
 .content-box {
@@ -130,12 +131,13 @@ body {
 
 .content-box p {
   line-height: 1.7;
-  margin-bottom: 3rem;
+  margin-bottom: 1.5rem;
 }
 
 .content-box a {
   color: var(--reader-link);
-  text-decoration: underline;
+  text-decoration: none;
+  font-weight: 600;
 }
 
 .content-box h1,
@@ -147,6 +149,33 @@ body {
   margin-top: 1.5rem;
   font-weight: bold;
   font-family: var(--reader-font-title);
+}
+
+/* custom headline classes */
+.headline1 {
+  font-family: var(--reader-font-title);
+  font-weight: bold;
+  font-size: 2.25rem;
+  line-height: 1.2;
+  color: var(--reader-title);
+}
+
+.headline2 {
+  font-family: var(--reader-font-title);
+  font-weight: bold;
+  font-size: 1.75rem;
+  line-height: 1.3;
+  margin-top: 1.2rem;
+  color: var(--reader-title);
+}
+
+.headline3 {
+  font-family: var(--reader-font-title);
+  font-weight: bold;
+  font-size: 1.4rem;
+  line-height: 1.3;
+  margin-top: 1rem;
+  color: var(--reader-title);
 }
 
 .content-inner img {   /* handles image size */

--- a/glossary.md
+++ b/glossary.md
@@ -3,7 +3,7 @@ layout: reader
 title: Glossary
 ---
 
-# Table of Contents
+<h2 class="headline2">Table of Contents</h2>
 
 * [Redefinition Of Terms](#h.1jd58yunhxko)
 * [Essence](#h.skqs6dqsczgc)
@@ -23,7 +23,7 @@ title: Glossary
 
 ---
 
-### Redefinition of Terms
+<h2 class="headline2">Redefinition of Terms</h2>
 
 <a name="h.1jd58yunhxko"></a>
 
@@ -39,7 +39,7 @@ Thus, when Sympnoia reuses old terms, it does so deliberately — not to preserv
 
 ---
 
-### Essence
+<h2 class="headline2">Essence</h2>
 
 <a name="h.skqs6dqsczgc"></a>
 
@@ -55,7 +55,7 @@ Ethical connection may reveal this pattern — but it does not constitute its to
 
 ---
 
-### Substance
+<h2 class="headline2">Substance</h2>
 
 <a name="h.e6k41ay20m5s"></a>
 
@@ -73,7 +73,7 @@ Thus, while Sympnoia reclaims many older terms — like [soul](#h.k9zbxd8uphcc),
 
 
 
-### Body
+<h2 class="headline2">Body</h2>
 
 <a name="h.o9o3801cv803"></a>
 
@@ -93,7 +93,7 @@ To ignore the body is to fracture experience. To coerce it is to teach it fear. 
 
 ---
 
-### Mind
+<h2 class="headline2">Mind</h2>
 
 <a name="h.2clv3j3uzqw2"></a>
 
@@ -113,7 +113,7 @@ Whether or not its processes are physically determined, the mind still behaves a
 
 
 
-### Soul
+<h2 class="headline2">Soul</h2>
 
 <a name="h.k9zbxd8uphcc"></a>
 
@@ -144,7 +144,7 @@ In this way, the Sympnoia soul is not a departure — but a convergence. A synth
 
 
 
-### Free Will
+<h2 class="headline2">Free Will</h2>
 
 <a name="h.v25j0klo3mgf"></a>
 
@@ -167,7 +167,7 @@ This is also why it is insufficient to reduce the discussion to the question of 
 
 ---
 
-### Posture
+<h2 class="headline2">Posture</h2>
 
 <a name="h.o66h3bqupqtx"></a>
 
@@ -187,7 +187,7 @@ Posture is where [truth](#h.x91heo89up22) becomes tangible — or is deflected. 
 
 ---
 
-### Ethical Action
+<h2 class="headline2">Ethical Action</h2>
 
 <a name="h.pdrxwmu8g8o"></a>
 
@@ -206,7 +206,7 @@ Thus, ethical action is not about purity — but about *honesty in motion*. It i
 In moments of ethical rupture — hesitation, guilt, or awakening — the soul is not destroyed, but *illuminated*. These moments are invitations to return to coherence. Not through perfection, but through [truth](#h.x91heo89up22).
 
 
-### Truth
+<h2 class="headline2">Truth</h2>
 
 <a name="h.x91heo89up22"></a>
 
@@ -226,7 +226,7 @@ Thus, truth in Sympnoia is not a possession. It is a way of being in the world �
 
 ---
 
-### Self
+<h2 class="headline2">Self</h2>
 
 <a name="h.k5f67shf1uqd"></a>
 
@@ -251,7 +251,7 @@ The body, mind, and world define the **coordinate space** — the relational fie
 
 ---
 
-### World
+<h2 class="headline2">World</h2>
 
 <a name="h.xlnhw1e1mvjn"></a>
 
@@ -265,7 +265,7 @@ The world, then, is not a static reality to be decoded, but a relational field t
 
 ---
 
-### Yin-Yang (☯)
+<h2 class="headline2">Yin-Yang (☯)</h2>
 
 <a name="h.l1d8ogrz7f6r"></a>
 


### PR DESCRIPTION
## Summary
- tweak reader color variables
- style paragraph links without underline
- add headline classes and custom margins
- adjust color handling in reader script
- convert glossary headings to headline2

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e828ad524832b96d862ef7fdc8b56